### PR TITLE
updating firecloud version to 0.16.29

### DIFF
--- a/pyAnVIL/requirements.txt
+++ b/pyAnVIL/requirements.txt
@@ -3,7 +3,7 @@
 
 ## core integration
 gen3==2.4.0
-firecloud==0.16.24
+firecloud==0.16.29
 
 # external requirements
 

--- a/pyAnVIL/setup.py
+++ b/pyAnVIL/setup.py
@@ -106,7 +106,7 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['gen3==2.4.0', 'firecloud==0.16.24'],  # Optional
+    install_requires=['gen3==2.4.0', 'firecloud==0.16.29'],  # Optional
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"


### PR DESCRIPTION
this FISS version contains features from https://github.com/broadinstitute/fiss/pull/146 which are used in a pyfilesystem2 AnVIL plugin; Galaxy uses said features to communicate with AnVIL